### PR TITLE
Prince errors

### DIFF
--- a/lib/princely.rb
+++ b/lib/princely.rb
@@ -24,6 +24,7 @@ module Princely
   autoload :Pdf,          'princely/pdf'
   autoload :Logging,      'princely/logging'
   autoload :Executable,   'princely/executable'
+  autoload :RenderError,   'princely/render_error'
 
   class << self
     def executable

--- a/lib/princely/pdf.rb
+++ b/lib/princely/pdf.rb
@@ -75,13 +75,7 @@ module Princely
       result.force_encoding('BINARY') if RUBY_VERSION >= "1.9"
 
       if errors.present?
-        puts "Log it to a logfile if required"
-
-        prince_errors = errors.scan(/^prince:\s(.*)$/).join("\n")
-
-        if prince_errors.present?
-          puts "Got some errors: #{prince_errors}"
-        end
+        handle_render_errors(errors)
       end
 
       result
@@ -93,7 +87,7 @@ module Princely
       errs.close
 
       if errors.present?
-        puts "HERE TOO some errors: #{errors}"
+        handle_render_errors(errors)
       end
 
       pdf
@@ -123,6 +117,16 @@ module Princely
       logger.info path
       #logger.debug source if source
       logger.info ''
+    end
+
+    def handle_render_errors(errors)
+      logger.error(errors)
+
+      prince_errors = errors.scan(/^prince:\s(.*)$/)
+
+      if prince_errors.any?
+        raise Princely::RenderError.new(prince_errors)
+      end
     end
   end
 end

--- a/lib/princely/pdf.rb
+++ b/lib/princely/pdf.rb
@@ -125,7 +125,11 @@ module Princely
       prince_errors = errors.scan(/^prince:\s(.*)$/)
 
       if prince_errors.any?
-        raise Princely::RenderError.new(prince_errors)
+        begin
+          raise Princely::RenderError.new(prince_errors)
+        rescue Princely::RenderError => exception
+          Appsignal.add_exception(exception)
+        end
       end
     end
   end

--- a/lib/princely/pdf.rb
+++ b/lib/princely/pdf.rb
@@ -51,7 +51,6 @@ module Princely
       options = []
       options << "--input=html"
       options << "--server" if @server_flag
-      # options << "--log=#{log_file}"
       options << "--media=#{media}" if media
       options << "--javascript" if @javascript
       options << @style_sheets
@@ -84,6 +83,8 @@ module Princely
     def pdf_from_string_to_file(string, output_file)
       pdf, errs = initialize_pdf_from_string(string, output_file)
       pdf.close
+
+      errors = errs.gets(nil)
       errs.close
 
       if errors.present?
@@ -95,14 +96,13 @@ module Princely
 
     protected
     def initialize_pdf_from_string(string, output_file, options = {})
-      options = {:log_command => true, :output_to_log_file => true}.merge(options)
+      options = {:log_command => true}.merge(options)
       path = exe_path
       # Don't spew errors to the standard out...and set up to take IO
       # as input and output
       path << " --media=#{media}" if media
       path << " --silent - -o #{output_file}"
       path << " --javascript" if @javascript
-      path << " >> '#{log_file}' 2>> '#{log_file}'" if options[:output_to_log_file]
 
       log_command(path, string) if options[:log_command]
       stdin, stdout, stderr, _ = Open3.popen3(path)

--- a/lib/princely/render_error.rb
+++ b/lib/princely/render_error.rb
@@ -1,0 +1,14 @@
+module Princely
+  class RenderError < StandardError
+
+    attr_accessor :render_errors
+
+    def initialize(render_errors)
+      @render_errors = render_errors
+    end
+
+    def message
+      "Prince couldn't render the pdf, errors:\n\t#{render_errors.join("\n\t")}"
+    end
+  end
+end

--- a/lib/princely/stdout_logger.rb
+++ b/lib/princely/stdout_logger.rb
@@ -3,5 +3,9 @@ module Princely
     def self.info(msg)
       puts msg
     end
+
+    def self.error(msg)
+      puts msg
+    end
   end
 end


### PR DESCRIPTION
Log prince stderr render errors to AppSignal whilst continuing to serve the PDF file.

Prince sends some errors to stderr and some to the log file when the --log option is passed. WIthout the --log option prince sends all the errors to stderr. The html file is sent in through stdin, the pdf will come out out of stdout, which is why popen3 is used